### PR TITLE
Update Transpose.BCL and Transpose.Core package references

### DIFF
--- a/Transpose.Plotly/Transpose.Plotly.csproj
+++ b/Transpose.Plotly/Transpose.Plotly.csproj
@@ -11,8 +11,8 @@
     <None Include="transpose-plotly-logo.png" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.2795" />
-    <PackageReference Include="Transpose.Core" Version="26.7.2771" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.2882" />
+    <PackageReference Include="Transpose.Core" Version="26.7.2884" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- Bumped `Transpose.BCL` from `26.7.2795` to `26.7.2882` in `Transpose.Plotly/Transpose.Plotly.csproj`
- Bumped `Transpose.Core` from `26.7.2771` to `26.7.2884` in `Transpose.Plotly/Transpose.Plotly.csproj`
- `Transpose.Build.Target` SDK version (`26.7.2692`) was already the latest available

## Test plan
- Not built or tested per request


---
_Generated by [Claude Code](https://claude.ai/code/session_013MUwRuKPJJ9WhDhepxAenV)_