### PR TITLE
Update NuGet package versions

### DIFF
--- a/Plotly.Samples/Plotly.Samples.csproj
+++ b/Plotly.Samples/Plotly.Samples.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3064" />
-    <PackageReference Include="Transpose.Core" Version="26.7.3065" />
-    <PackageReference Include="Tesserae" Version="2026.7.68604" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3120" />
+    <PackageReference Include="Transpose.Core" Version="26.7.3122" />
+    <PackageReference Include="Tesserae" Version="2026.7.68668" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tesserae.Plotly/Tesserae.Plotly.csproj
+++ b/Tesserae.Plotly/Tesserae.Plotly.csproj
@@ -11,9 +11,9 @@
     <None Include="tesserae-plotly-logo.png" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.7.3064" />
-    <PackageReference Include="Transpose.Core" Version="26.7.3065" />
-    <PackageReference Include="Tesserae" Version="2026.7.68604" />
+    <PackageReference Include="Transpose.BCL" Version="26.7.3120" />
+    <PackageReference Include="Transpose.Core" Version="26.7.3122" />
+    <PackageReference Include="Tesserae" Version="2026.7.68668" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- Bump `Transpose.BCL` 26.7.3064 → 26.7.3120, `Transpose.Core` 26.7.3065 → 26.7.3122, and `Tesserae` 2026.7.68604 → 2026.7.68668 in `Plotly.Samples` and `Tesserae.Plotly`
- `Microsoft.CSharp` (4.7.0) and `Newtonsoft.Json` (13.0.4) in `Plotly.Sharp` were already on the latest stable versions, so left unchanged

## Test plan
- [ ] Not run per request (packages updated without running build/test)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GL9NFXk3BquePa324BXxzK)_