### PR TITLE
Fix unhandled promise rejections in Plotly resize operations

### DIFF
--- a/Tesserae.Plotly/Bindings.cs
+++ b/Tesserae.Plotly/Bindings.cs
@@ -223,13 +223,12 @@ namespace Tesserae.Plotly
 
                             void OnResize()
                             {
-                                // The resize call will fail if the chart is currently in a hidden state - if this is the case then swallow the exception (it's not recommended, though, since there is no support for the story
-                                // where the chart gets hidden, the User resizes the window and then the chart gets shown again; it may no longer be the correct size after the resize)
-                                try
-                                {
-                                    Script.Write("Plotly.Plots.resize({0})", Container);
-                                }
-                                catch { }
+                                // The resize call rejects a Promise (rather than throwing synchronously) if the chart is currently in
+                                // a hidden state - a plain try/catch around the call cannot catch that, so it surfaces as an unhandled
+                                // promise rejection instead. Swallow it on the JS side (it's not recommended, though, since there is no
+                                // support for the story where the chart gets hidden, the User resizes the window and then the chart
+                                // gets shown again; it may no longer be the correct size after the resize)
+                                Script.Write("Plotly.Plots.resize({0}).catch(function(){})", Container);
                             }
 
                             void OnResizeEvent(Event e) => OnResize();

--- a/Tesserae.Plotly/PlotlyChart.cs
+++ b/Tesserae.Plotly/PlotlyChart.cs
@@ -251,7 +251,13 @@ namespace Tesserae.Plotly
             window.clearTimeout(_resizeTimeout);
             _resizeTimeout = window.setTimeout((_) =>
             {
-                try { Script.Write("Plotly.Plots.resize({0})", _container); } catch { }
+                // Re-check on the timer tick: the container may have been hidden/unmounted since this was scheduled.
+                if (!_rendered || !_container.IsMounted()) return;
+
+                // Plotly.Plots.resize() rejects a Promise (rather than throwing synchronously) when the div isn't
+                // currently displayed, e.g. it sits inside a hidden tab/pivot - a plain try/catch around the call
+                // cannot catch that, so it surfaces as an unhandled promise rejection. Swallow it on the JS side.
+                Script.Write("Plotly.Plots.resize({0}).catch(function(){})", _container);
             }, 16);
         }
 


### PR DESCRIPTION
## Summary
Updated Plotly resize calls to properly handle promise rejections that occur when charts are in hidden states, preventing unhandled promise rejection errors.

## Key Changes
- **Bindings.cs**: Modified the `OnResize()` method to chain a `.catch()` handler to the `Plotly.Plots.resize()` promise instead of relying on a try/catch block, which cannot catch asynchronous promise rejections
- **PlotlyChart.cs**: Updated `ScheduleResize()` to:
  - Add a runtime check to verify the container is still mounted before attempting resize
  - Chain a `.catch()` handler to the `Plotly.Plots.resize()` promise for proper error handling
  - Improved comments to clarify that Plotly rejects promises asynchronously rather than throwing synchronously

## Implementation Details
The core issue is that `Plotly.Plots.resize()` returns a Promise that rejects when the chart div is hidden (e.g., in a hidden tab or unmounted state). A synchronous try/catch block cannot catch asynchronous promise rejections, so they surface as unhandled promise rejection errors. By chaining `.catch(function(){})` on the promise itself, these rejections are properly swallowed on the JavaScript side.

The additional check in `PlotlyChart.cs` provides an extra safety measure to avoid unnecessary resize attempts when the container is no longer mounted.

https://claude.ai/code/session_0126U8MhREatKG5t2v2uze4t