### PR TITLE
Update the Transpose packages to the latest release

### DIFF
--- a/Plotly.Samples/Plotly.Samples.csproj
+++ b/Plotly.Samples/Plotly.Samples.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.2692">
+<Project Sdk="Transpose.Build.Target/26.8.4125">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Plotly.Samples</AssemblyName>
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4500" />
-    <PackageReference Include="Transpose.Core" Version="26.8.4176" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
+    <PackageReference Include="Transpose.Core" Version="26.8.4597" />
     <PackageReference Include="Tesserae" Version="2026.8.70037" />
   </ItemGroup>
 

--- a/Tesserae.Plotly/Tesserae.Plotly.csproj
+++ b/Tesserae.Plotly/Tesserae.Plotly.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Transpose.Build.Target/26.7.2692">
+<Project Sdk="Transpose.Build.Target/26.8.4125">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <SkipResourcesExtraction>true</SkipResourcesExtraction>
@@ -11,8 +11,8 @@
     <None Include="tesserae-plotly-logo.png" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Transpose.BCL" Version="26.8.4500" />
-    <PackageReference Include="Transpose.Core" Version="26.8.4176" />
+    <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
+    <PackageReference Include="Transpose.Core" Version="26.8.4597" />
     <PackageReference Include="Tesserae" Version="2026.8.70037" />
   </ItemGroup>
 


### PR DESCRIPTION
Moves every `Transpose.*` reference to the current published release, in `Tesserae.Plotly` and `Plotly.Samples` alike.

| Package | From | To |
| --- | --- | --- |
| `Transpose.BCL` | 26.8.4500 | **26.8.4619** |
| `Transpose.Core` | 26.8.4176 | **26.8.4597** |
| `Transpose.Build.Target` (SDK) | 26.7.2692 | **26.8.4125** |

The SDK pin is the one worth a second look: the last few package updates here moved the `PackageReference`s and left the `Sdk=` line alone, so 26.7.2692 was the oldest Transpose SDK pin left across these repositories. It is now on the same 26.8.4125 as everything else.

## The compiler this needs

`Transpose.BCL` 26.8.4619 carries a build stamp of `26.8.4618`, so a consumer needs `Transpose.Compiler` >= 26.8.4618 or the build fails with `TPS0008`. That is the newest published compiler, and it is what `dotnet tool update --global Transpose.Compiler` in `.devops/build-nuget.yml` installs. `Transpose.Core` 26.8.4597 stamps 26.8.4595, so it is covered by the same floor.

## Verification

Built `Plotly.Samples` in **Release** against compiler 26.8.4618, no warnings and no errors — which builds `Tesserae.Plotly` as a package on the way. Release specifically, because the `.min.js` resource selection only happens there.

`Plotly.Generator` is an ordinary .NET project and is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_011QmFZNQ8Tn48gznUET3t3U)_