### PR TITLE
Update Tesserae to 2026.8.70157

### DIFF
--- a/Plotly.Samples/Plotly.Samples.csproj
+++ b/Plotly.Samples/Plotly.Samples.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
     <PackageReference Include="Transpose.Core" Version="26.8.4597" />
-    <PackageReference Include="Tesserae" Version="2026.8.70037" />
+    <PackageReference Include="Tesserae" Version="2026.8.70157" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tesserae.Plotly/Tesserae.Plotly.csproj
+++ b/Tesserae.Plotly/Tesserae.Plotly.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Transpose.BCL" Version="26.8.4619" />
     <PackageReference Include="Transpose.Core" Version="26.8.4597" />
-    <PackageReference Include="Tesserae" Version="2026.8.70037" />
+    <PackageReference Include="Tesserae" Version="2026.8.70157" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
`Tesserae` 2026.8.70037 → **2026.8.70157** in `Tesserae.Plotly` and `Plotly.Samples`.

## Why this is stacked on #15 rather than opened against `master`

Tesserae 2026.8.70157 declares `Transpose.BCL >= 26.8.4619` and `Transpose.Core >= 26.8.4597` — exactly the versions #15 moves to. Against `master` the restore does not merely warn, it fails:

```
error NU1605: Warning As Error: Detected package downgrade: Transpose.BCL from 26.8.4619 to 26.8.4500
  Tesserae.Plotly -> Tesserae 2026.8.70157 -> Transpose.BCL (>= 26.8.4619)
  Tesserae.Plotly -> Transpose.BCL (>= 26.8.4500)
```

So this genuinely depends on #15 and is based on its branch; the diff here is only the two Tesserae lines. Merge #15 first and GitHub will retarget this to `master`.

## Verification

Built `Plotly.Samples` in **Release** — which builds `Tesserae.Plotly` as a package on the way — with a clean restore (no NU1605).

Driven in headless Chromium: the sample renders, 675 nodes, with no console error beyond a missing `/favicon.ico` (every sample site in this family logs it; confirmed with `curl`, none ship one).

`Plotly.Generator` is an ordinary .NET project and is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_011QmFZNQ8Tn48gznUET3t3U)_